### PR TITLE
use "ahk" as docset Identifier

### DIFF
--- a/autohotkey.docset/Contents/Info.plist
+++ b/autohotkey.docset/Contents/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>autohotkey</string>
+    <string>ahk</string>
     <key>CFBundleName</key>
     <string>Autohotkey</string>
     <key>DocSetPlatformFamily</key>
-    <string>autohotkey</string>
+    <string>ahk</string>
     <key>isDashDocset</key>
     <true/>
     <key>isJavaScriptEnabled</key>

--- a/autohotkey.docset/Contents/Info.plist
+++ b/autohotkey.docset/Contents/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleIdentifier</key>
     <string>ahk</string>
     <key>CFBundleName</key>
-    <string>Autohotkey</string>
+    <string>AutoHotkey</string>
     <key>DocSetPlatformFamily</key>
     <string>ahk</string>
     <key>isDashDocset</key>

--- a/autohotkey.docset/meta.json
+++ b/autohotkey.docset/meta.json
@@ -1,6 +1,6 @@
 {
-    "name": "AutoHotKey",
+    "name": "AutoHotkey",
     "sourceId": "com.kapeli",
-    "title": "AutoHotKey L",
-    "version": "1.1.22.07"
+    "title": "AutoHotkey L",
+    "version": "1.1.23.01"
 }


### PR DESCRIPTION
This way, `ahk:` prefix searches in AutoHotkey docset (in Zeal at least).
<img src="http://i.imgur.com/B2V7k1r.png">

Also avoids listing AutoIt3 terms in search results.
